### PR TITLE
Always return local time

### DIFF
--- a/Assets/Scripts/iOS/iOSGameNotification.cs
+++ b/Assets/Scripts/iOS/iOSGameNotification.cs
@@ -105,10 +105,10 @@ namespace NotificationSamples.iOS
                     calendarTrigger.Hour ?? now.Hour,
                     calendarTrigger.Minute ?? now.Minute,
                     calendarTrigger.Second ?? now.Second,
-                    DateTimeKind.Local
+                    calendarTrigger.UtcTime ? DateTimeKind.Utc : DateTimeKind.Local
                     );
 
-                return result;
+                return result.ToLocalTime();
             }
             set
             {


### PR DESCRIPTION
When using Calendar trigger, we use UTC time.
However, the sample project queries it and compares against local time, and C# DateTime sadly ignores the kind, so comparisons are wrong. Turns out some people actually use code from this sample in their project running into issues.
Change querying to always return local time here (related PR in the package to address the possibility of same issue when using directly).