### PR TITLE
Fix permissions

### DIFF
--- a/Assets/Demo/NotificationConsole.cs
+++ b/Assets/Demo/NotificationConsole.cs
@@ -68,7 +68,7 @@ namespace NotificationSamples.Demo
             }
         }
 
-        private void Start()
+        private IEnumerator Start()
         {
             // Set up channels (mostly for Android)
             // You need to have at least one of these
@@ -76,7 +76,7 @@ namespace NotificationSamples.Demo
             var c2 = new GameNotificationChannel(NewsChannelId, "News Channel", "News feed notifications");
             var c3 = new GameNotificationChannel(ReminderChannelId, "Reminder Channel", "Reminder notifications");
 
-            manager.Initialize(c1, c2, c3);
+            return manager.Initialize(c1, c2, c3);
         }
 
         private void OnDestroy()

--- a/Assets/Scripts/Android/AndroidNotificationsPlatform.cs
+++ b/Assets/Scripts/Android/AndroidNotificationsPlatform.cs
@@ -1,5 +1,6 @@
 #if UNITY_ANDROID
 using System;
+using System.Collections;
 using Unity.Notifications.Android;
 
 namespace NotificationSamples.Android
@@ -25,6 +26,13 @@ namespace NotificationSamples.Android
         public AndroidNotificationsPlatform()
         {
             AndroidNotificationCenter.OnNotificationReceived += OnLocalNotificationReceived;
+        }
+
+        public IEnumerator RequestNotificationPermission()
+        {
+            var request = new PermissionRequest();
+            while (request.Status == PermissionStatus.RequestPending)
+                yield return null;
         }
 
         /// <inheritdoc />

--- a/Assets/Scripts/GameNotificationsManager.cs
+++ b/Assets/Scripts/GameNotificationsManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -316,7 +317,7 @@ namespace NotificationSamples
         /// </summary>
         /// <param name="channels">An optional collection of channels to register, for Android</param>
         /// <exception cref="InvalidOperationException"><see cref="Initialize"/> has already been called.</exception>
-        public void Initialize(params GameNotificationChannel[] channels)
+        public IEnumerator Initialize(params GameNotificationChannel[] channels)
         {
             if (Initialized)
             {
@@ -363,7 +364,7 @@ namespace NotificationSamples
 
             if (Platform == null)
             {
-                return;
+                yield break;
             }
 
             PendingNotifications = new List<PendingNotification>();
@@ -374,6 +375,8 @@ namespace NotificationSamples
             {
                 Serializer = new DefaultSerializer(Path.Combine(Application.persistentDataPath, DefaultFilename));
             }
+
+            yield return Platform.RequestNotificationPermission();
 
             OnForegrounding();
         }

--- a/Assets/Scripts/IGameNotificationsPlatform.cs
+++ b/Assets/Scripts/IGameNotificationsPlatform.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 
 namespace NotificationSamples
 {
@@ -11,6 +12,8 @@ namespace NotificationSamples
         /// Fired when a notification is received.
         /// </summary>
         event Action<IGameNotification> NotificationReceived;
+
+        IEnumerator RequestNotificationPermission();
 
         /// <summary>
         /// Create a new instance of a <see cref="IGameNotification"/> for this platform.

--- a/Assets/Scripts/iOS/iOSNotificationsPlatform.cs
+++ b/Assets/Scripts/iOS/iOSNotificationsPlatform.cs
@@ -1,5 +1,6 @@
 #if UNITY_IOS
 using System;
+using System.Collections;
 using Unity.Notifications.iOS;
 
 namespace NotificationSamples.iOS
@@ -19,6 +20,15 @@ namespace NotificationSamples.iOS
         public iOSNotificationsPlatform()
         {
             iOSNotificationCenter.OnNotificationReceived += OnLocalNotificationReceived;
+        }
+
+        public IEnumerator RequestNotificationPermission()
+        {
+            using (var request = new AuthorizationRequest(AuthorizationOption.Badge | AuthorizationOption.Sound | AuthorizationOption.Alert, false))
+            {
+                while (!request.IsFinished)
+                    yield return null;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fix notification permissions in project.
After support for Provisional authorization was added to iOS, notifications no longer work in this project, because default ask is with provisional which is auto-granted and causes notifications to work silently.
With Android 13 we also have to support notification permission too.
This PR adds permission requesting in code for both platforms. While iOS could be set up in settings, I think it's better to do this in code to show how it's done on both platforms.